### PR TITLE
Changed mode to retrieve course fullname

### DIFF
--- a/classes/condition.php
+++ b/classes/condition.php
@@ -81,19 +81,19 @@ class condition extends \core_availability\condition {
 
     public function is_available($not, \core_availability\info $info, $grabthelot, $userid) {
         //get course completion details to allow preview
-        
+
         global $DB;
 
         $course = $this->cmid;
         $user = $DB->get_record('course_completions', array('userid'=> $userid, 'course'=> $course));
-        
+
         //if data is available means user has been completed course
         if($user->id > 0 && $user->timecompleted != NULL){
 
-            $allow = true; 
+            $allow = true;
         }
         else{
-            $allow = false; 
+            $allow = false;
         }
 
         return $allow;
@@ -118,16 +118,10 @@ class condition extends \core_availability\condition {
         }
     }
 
-    //get details restrict access 
+    //get details restrict access
     public function get_description($full, $not, \core_availability\info $info) {
         // Get name for module.
-        $modc = get_courses();
-
-        foreach ($modc as $modcs) {
-            if($modcs->id == $this->cmid){
-                $modname = $modcs->fullname;
-            }
-        }
+        $modname = $DB->get_record('course', ['id' => $this->cmid])->fullname;
 
         // Work out which lang string to use.
         if ($not) {
@@ -147,7 +141,7 @@ class condition extends \core_availability\condition {
         } else {
             $str = 'requires_' . self::get_lang_string_keyword($this->expectedcompletion);
         }
-        
+
         return get_string($str, 'availability_othercompleted', $modname);
     }
 

--- a/classes/condition.php
+++ b/classes/condition.php
@@ -120,6 +120,7 @@ class condition extends \core_availability\condition {
 
     //get details restrict access
     public function get_description($full, $not, \core_availability\info $info) {
+      global $DB;
         // Get name for module.
         $modname = $DB->get_record('course', ['id' => $this->cmid])->fullname;
 

--- a/version.php
+++ b/version.php
@@ -24,8 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2019121000;
+$plugin->version = 2020040800;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 2019121000;
 $plugin->component = 'availability_othercompleted';                                                                                                                                                
-


### PR DESCRIPTION
Hi,
thank you for the awasome plugin, i've created this pull request because i've need to show the title of the course used in the condition of an activity also to that user that do not have the right to see the course.
Now they can just see the name of the course, instead of a not filled placeholder.

Don't know if it is an issue, but if it is intended to not show the title of course that the user can't see, i think is better to not show the sentences at all, or to show something like "Access denied".

I can work on a new version where that things can be controlled in the system preferences if needed.