### PR TITLE
Update frontend.php - fix for moodle 4.5

### DIFF
--- a/classes/frontend.php
+++ b/classes/frontend.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Front-end class.
+ * Front-end class for the other course completion availability condition.
  *
  * @package availability_othercompleted
  * @copyright MU DOT MY PLT <support@mu.my>
@@ -24,25 +24,51 @@
 
 namespace availability_othercompleted;
 
-defined('MOODLE_INTERNAL') || die();
-
+/**
+ * Front-end class for the other course completion availability condition.
+ *
+ * @package availability_othercompleted
+ * @copyright MU DOT MY PLT <support@mu.my>
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 class frontend extends \core_availability\frontend {
     /**
      * @var array Cached init parameters
      */
-    protected $cacheparams = array();
+    protected $cacheparams = [];
 
     /**
      * @var string IDs of course, cm, and section for cache (if any)
      */
     protected $cachekey = '';
 
+    /**
+     * @var array Cache for the initialization parameters
+     */
+    protected $cacheinitparams = [];
+
+    /**
+     * Gets a list of JavaScript strings required for this module.
+     *
+     * @return array Array of required string identifiers
+     */
     protected function get_javascript_strings() {
-        return array('option_complete', 'label_cm', 'label_completion');
+        return ['option_complete', 'label_cm', 'label_completion'];
     }
 
-    protected function get_javascript_init_params($course, \cm_info $cm = null,
-            \section_info $section = null) {
+    /**
+     * Gets parameters for the JavaScript init function.
+     *
+     * @param \stdClass $course The course object
+     * @param ?\cm_info $cm Course module info object (optional)
+     * @param ?\section_info $section Section info object (optional)
+     * @return array Array of parameters for the JavaScript function
+     */
+    protected function get_javascript_init_params(
+        $course,
+        ?\cm_info $cm = null,
+        ?\section_info $section = null
+    ) {
         // Use cached result if available. The cache is just because we call it
         // twice (once from allow_add) so it's nice to avoid doing all the
         // print_string calls twice.
@@ -51,31 +77,39 @@ class frontend extends \core_availability\frontend {
             // Get list of activities on course which have completion values,
             // to fill the dropdown.
             $context = \context_course::instance($course->id);
-            // get all course name
-            $datcms = array();
+            $datcms = [];
             global $DB;
-            $sql2 = "SELECT * FROM {course} 
+            $sql2 = "SELECT * FROM {course}
                     ORDER BY fullname ASC";
             $other = $DB->get_records_sql($sql2);
-            // $other = get_courses();
             foreach ($other as $othercm) {
-                // disable not created course and default course
-                if(($othercm->category > 0) && ($othercm->id != $course->id)){
-                        $datcms[] = (object)array(
+                // Disable not created course and default course.
+                if (($othercm->category > 0) && ($othercm->id != $course->id)) {
+                        $datcms[] = (object)[
                             'id' => $othercm->id,
-                            'name' => format_string($othercm->fullname, true, array('context' => $context))
-                            // 'completiongradeitemnumber' => $othercm->completiongradeitemnumber
-                        );
+                            'name' => format_string($othercm->fullname, true, ['context' => $context]),
+                        ];
                 }
             }
             $this->cachekey = $cachekey;
-            $this->cacheinitparams = array($datcms);
+            $this->cacheinitparams = [$datcms];
         }
         return $this->cacheinitparams;
     }
 
-    protected function allow_add($course, \cm_info $cm = null,
-            \section_info $section = null) {
+    /**
+     * Determines whether this availability condition can be added to a course/module.
+     *
+     * @param \stdClass $course The course object
+     * @param ?\cm_info $cm Course module info object (optional)
+     * @param ?\section_info $section Section info object (optional)
+     * @return bool True if this condition can be added, false otherwise
+     */
+    protected function allow_add(
+        $course,
+        ?\cm_info $cm = null,
+        ?\section_info $section = null
+    ) {
         global $CFG;
 
         // Check if completion is enabled for the course.


### PR DESCRIPTION
This is happening because PHP 8.2+ has made dynamic property creation deprecated. We need to properly declare the properties in the class.